### PR TITLE
Fix `memory` and `cpu` ` limits` to avoid `CrashLoopBackOff`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         apps: ["cart", "checkout", "currency", "email", "frontend", "loadgenerator", "payment", "productcatalog", "recommendation", "shipping"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       HUMCTL_VERSION: '0.24.0'
     steps:
@@ -26,7 +26,7 @@ jobs:
               --org ${{ secrets.HUMANITEC_ORG }} \
               --strict
   score-compose:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SCORE_COMPOSE_VERSION: 'latest'
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         apps: ["cart", "checkout", "currency", "email", "frontend", "loadgenerator", "payment", "productcatalog", "recommendation", "shipping"]
     runs-on: ubuntu-24.04
     env:
-      HUMCTL_VERSION: '0.24.0'
+      HUMCTL_VERSION: '0.25.0'
     steps:
       - name: checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/close-pr.yaml
+++ b/.github/workflows/close-pr.yaml
@@ -5,7 +5,7 @@ on:
       - closed
 env:
   ENVIRONMENT_ID: pr-${{ github.event.number }}
-  HUMCTL_VERSION: '0.24.0'
+  HUMCTL_VERSION: '0.25.0'
 jobs:
   job:
     runs-on: ubuntu-24.04

--- a/.github/workflows/close-pr.yaml
+++ b/.github/workflows/close-pr.yaml
@@ -8,7 +8,7 @@ env:
   HUMCTL_VERSION: '0.24.0'
 jobs:
   job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout humctl bin
         uses: actions/checkout@v4

--- a/.github/workflows/open-pr.yaml
+++ b/.github/workflows/open-pr.yaml
@@ -12,7 +12,7 @@ env:
   HUMCTL_VERSION: '0.24.0'
 jobs:
   job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/open-pr.yaml
+++ b/.github/workflows/open-pr.yaml
@@ -9,7 +9,7 @@ env:
   ENVIRONMENT_TYPE: 'development'
   ENVIRONMENT_ID: pr-${{ github.event.number }}
   ENVIRONMENT_NAME: PR-${{ github.event.number }}
-  HUMCTL_VERSION: '0.24.0'
+  HUMCTL_VERSION: '0.25.0'
 jobs:
   job:
     runs-on: ubuntu-24.04

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -10,7 +10,7 @@ env:
   HUMCTL_VERSION: '0.24.0'
 jobs:
   deploy-humanitec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: install humctl

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -7,7 +7,7 @@ on:
       - 'v*'
 env:
   ENVIRONMENT_ID: development
-  HUMCTL_VERSION: '0.24.0'
+  HUMCTL_VERSION: '0.25.0'
 jobs:
   deploy-humanitec:
     runs-on: ubuntu-24.04

--- a/apps/ad/score.yaml
+++ b/apps/ad/score.yaml
@@ -9,10 +9,10 @@ containers:
     resources:
       limits:
         memory: "150Mi"
-        cpu: "150m"
+        cpu: "250m"
       requests:
         memory: "120Mi"
-        cpu: "120m"
+        cpu: "230m"
 service:
   ports:
     grpc:

--- a/apps/ad/score.yaml
+++ b/apps/ad/score.yaml
@@ -9,10 +9,10 @@ containers:
     resources:
       limits:
         memory: "150Mi"
-        cpu: "250m"
+        cpu: "280m"
       requests:
         memory: "120Mi"
-        cpu: "230m"
+        cpu: "250m"
 service:
   ports:
     grpc:

--- a/apps/ad/score.yaml
+++ b/apps/ad/score.yaml
@@ -8,11 +8,11 @@ containers:
       PORT: "9555"
     resources:
       limits:
-        memory: "100Mi"
-        cpu: "80m"
+        memory: "150Mi"
+        cpu: "150m"
       requests:
-        memory: "80Mi"
-        cpu: "60m"
+        memory: "120Mi"
+        cpu: "120m"
 service:
   ports:
     grpc:

--- a/apps/checkout/score.yaml
+++ b/apps/checkout/score.yaml
@@ -15,10 +15,10 @@ containers:
     resources:
       limits:
         memory: "80Mi"
-        cpu: "30m"
+        cpu: "60m"
       requests:
         memory: "60Mi"
-        cpu: "10m"
+        cpu: "40m"
 resources:
   cartservice:
     type: service

--- a/apps/checkout/score.yaml
+++ b/apps/checkout/score.yaml
@@ -14,10 +14,10 @@ containers:
       SHIPPING_SERVICE_ADDR: "${resources.shippingservice.name}:50051"
     resources:
       limits:
-        memory: "40Mi"
+        memory: "80Mi"
         cpu: "30m"
       requests:
-        memory: "20Mi"
+        memory: "60Mi"
         cpu: "10m"
 resources:
   cartservice:

--- a/apps/currency/score.yaml
+++ b/apps/currency/score.yaml
@@ -9,10 +9,10 @@ containers:
       PORT: "7000"
     resources:
       limits:
-        memory: "60Mi"
+        memory: "90Mi"
         cpu: "40m"
       requests:
-        memory: "40Mi"
+        memory: "70Mi"
         cpu: "20m"
 service:
   ports:

--- a/apps/currency/score.yaml
+++ b/apps/currency/score.yaml
@@ -10,10 +10,10 @@ containers:
     resources:
       limits:
         memory: "90Mi"
-        cpu: "40m"
+        cpu: "140m"
       requests:
         memory: "70Mi"
-        cpu: "20m"
+        cpu: "120m"
 service:
   ports:
     grpc:

--- a/apps/email/score.yaml
+++ b/apps/email/score.yaml
@@ -10,10 +10,10 @@ containers:
     resources:
       limits:
         memory: "70Mi"
-        cpu: "30m"
+        cpu: "130m"
       requests:
         memory: "50Mi"
-        cpu: "10m"
+        cpu: "110m"
 service:
   ports:
     grpc:

--- a/apps/frontend/score.yaml
+++ b/apps/frontend/score.yaml
@@ -35,11 +35,11 @@ containers:
       ENABLE_ASSISTANT: "false"
     resources:
       limits:
-        memory: "128Mi"
-        cpu: "200m"
+        memory: "50Mi"
+        cpu: "50m"
       requests:
-        memory: "40Mi"
-        cpu: "40m"
+        memory: "30Mi"
+        cpu: "30m"
 resources:
   adservice:
     type: service

--- a/apps/loadgenerator/score.yaml
+++ b/apps/loadgenerator/score.yaml
@@ -10,10 +10,10 @@ containers:
     resources:
       limits:
         memory: "220Mi"
-        cpu: "30m"
+        cpu: "100m"
       requests:
         memory: "200Mi"
-        cpu: "10m"
+        cpu: "80m"
 resources:
   frontend:
     type: service


### PR DESCRIPTION
Following up on https://github.com/Humanitec-DemoOrg/onlineboutique-demo/pull/25, continuing testing https://github.com/GoogleCloudPlatform/microservices-demo/pull/2540

 Nothing related, but also took the initiative to:
 
 - Update `humctl` to '0.25.0'
 - Update the GitHub runner to Ubuntu `24.04` 